### PR TITLE
Fix duplicate releases being created

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,9 @@ gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production
 gem 'redis', '~> 4.0'
 
+# Distributed mutex in Ruby using Redis. Supports both blocking and non-blocking semantics.
+gem 'redis-mutex'
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,6 +318,12 @@ GEM
       railties (>= 3.2)
       tilt
     redis (4.1.3)
+    redis-classy (2.4.1)
+      redis-namespace (~> 1.0)
+    redis-mutex (4.0.2)
+      redis-classy (~> 2.0)
+    redis-namespace (1.7.0)
+      redis (>= 3.0.4)
     regexp_parser (1.7.0)
     rexml (3.2.4)
     rspec (3.9.0)
@@ -493,6 +499,7 @@ DEPENDENCIES
   rbnacl (>= 3.2, < 5.0)
   react-rails
   redis (~> 4.0)
+  redis-mutex
   rspec
   rspec-collection_matchers
   rspec-html-matchers

--- a/config/initializers/redis_mutex.rb
+++ b/config/initializers/redis_mutex.rb
@@ -1,0 +1,2 @@
+RedisClassy.redis = Redis.new
+RedisClassy.ping


### PR DESCRIPTION
If you merge multiple PRs at the same time, it is possible for drake to create two release on github with the same version number.

This introduces redis mutex to lock around the operation of looking up the releases, and creating/editing the release on the github repo.

TODO:
* [ ] Spec